### PR TITLE
onAreaTapped no longer ran when the guardComingFrom prevented the animation

### DIFF
--- a/lib/actors/smart_flare_actor.dart
+++ b/lib/actors/smart_flare_actor.dart
@@ -24,7 +24,7 @@ class SmartFlareActor extends StatefulWidget {
   final List<ActiveArea> activeAreas;
 
   /// When true the starting animation will be played on actions that rebuild the widget
-  /// 
+  ///
   /// Set to true when you want the starting animation to play whenever you navigate back to a view
   final bool playStartingAnimationWhenRebuilt;
 
@@ -68,8 +68,11 @@ class _SmartFlareActorState extends State<SmartFlareActor> {
       _controller = TapController();
     }
 
-    if(widget.startingAnimation != null && widget.playStartingAnimationWhenRebuilt) {
-      (_controller as TapController).playAnimation(ActiveArea(animationName: widget.startingAnimation, area: Rect.fromLTRB(0, 0, 1, 1)));
+    if (widget.startingAnimation != null &&
+        widget.playStartingAnimationWhenRebuilt) {
+      (_controller as TapController).playAnimation(ActiveArea(
+          animationName: widget.startingAnimation,
+          area: Rect.fromLTRB(0, 0, 1, 1)));
     }
 
     var interactableWidgets = List<Widget>();
@@ -130,6 +133,25 @@ class _SmartFlareActorState extends State<SmartFlareActor> {
     return GestureDetector(
       onTap: () {
         playAnimation(activeArea);
+        if (activeArea.hasAnimationGuard) {
+          if (_controller != null) {
+            if (_controller is TapController) {
+              if ((_controller as TapController).lastPlayedAnimation != null) {
+                if (activeArea.guardComingFrom.contains(
+                    (_controller as TapController).lastPlayedAnimation)) {
+                  return;
+                }
+              }
+              if ((_controller as TapController).lastPlayedCycleAnimation !=
+                  null) {
+                if (activeArea.guardComingFrom.contains(
+                    (_controller as TapController).lastPlayedCycleAnimation)) {
+                  return;
+                }
+              }
+            }
+          }
+        }
 
         if (activeArea.onAreaTapped != null) {
           activeArea.onAreaTapped();

--- a/lib/controllers/tap_controller.dart
+++ b/lib/controllers/tap_controller.dart
@@ -4,8 +4,8 @@ import 'package:smart_flare/reducers.dart';
 import '../models.dart';
 
 class TapController extends FlareControls {
-  String _lastPlayedAnimation;
-  String _lastPlayedCycleAnimation;
+  String lastPlayedAnimation;
+  String lastPlayedCycleAnimation;
 
   void playAnimation(ActiveArea activeArea) {
     var animationName = getAnimationToPlay(activeArea);
@@ -13,23 +13,25 @@ class TapController extends FlareControls {
     // DOING: When cycling through animations, the same animation should never play twice,
     // always advance
 
-    print('LastPlayedCycleAnimation: $_lastPlayedCycleAnimation, hascycleAnimation: ${activeArea.hasCycleAnimations}');
-    if(activeArea.hasCycleAnimations && _lastPlayedCycleAnimation == animationName) {
+    print(
+        'LastPlayedCycleAnimation: $lastPlayedCycleAnimation, hascycleAnimation: ${activeArea.hasCycleAnimations}');
+    if (activeArea.hasCycleAnimations &&
+        lastPlayedCycleAnimation == animationName) {
       animationName = activeArea.getNextAnimation();
     }
 
     if (activeArea.hasAnimationGuard &&
-        activeArea.guardComingFrom.contains(_lastPlayedAnimation)) {
+        activeArea.guardComingFrom.contains(lastPlayedAnimation)) {
       // print('SmartFlare:Info - Last played animation is $_lastPlayedAnimation and $animationName has a guard against it');
       return;
     }
 
     play(animationName);
 
-    _lastPlayedAnimation = animationName;
+    lastPlayedAnimation = animationName;
 
-    if(activeArea.hasCycleAnimations) {
-      _lastPlayedCycleAnimation = animationName;
+    if (activeArea.hasCycleAnimations) {
+      lastPlayedCycleAnimation = animationName;
     }
   }
 }


### PR DESCRIPTION
This fixes this issue https://github.com/FilledStacks/smart_flare/issues/3
I suppose there might be a better way to get it done, but it does the job for me.