### PR TITLE
Fix for issue with PanFlareActor

### DIFF
--- a/lib/actors/smart_flare_actor.dart
+++ b/lib/actors/smart_flare_actor.dart
@@ -164,10 +164,10 @@ class _SmartFlareActorState extends State<SmartFlareActor> {
         width: width,
         height: height,
         decoration: BoxDecoration(
-            color: activeArea.debugArea
+            color: (activeArea.debugArea??false)
                 ? Color.fromARGB(80, 256, 0, 0)
                 : Colors.transparent,
-            border: activeArea.debugArea
+            border: (activeArea.debugArea??false)
                 ? Border.all(color: borderColor, width: 1.0)
                 : null));
   }


### PR DESCRIPTION
If debugArea is not provided,  line number 167 & 170 throws error as null value is can not be used as boolean expression.
Issue submitted by me here:
https://github.com/FilledStacks/smart_flare/issues/5